### PR TITLE
Updates for Spark 1.6.0

### DIFF
--- a/jvm/pom.xml
+++ b/jvm/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spark.version>1.3.0-cdh5.4.0</spark.version>
+    <spark.version>1.6.0-cdh5.7.0</spark.version>
     <java.version>1.8</java.version>
     <sparkts.version>0.3.0</sparkts.version>
   </properties>

--- a/jvm/src/main/java/com/cloudera/tsexamples/JavaStocks.java
+++ b/jvm/src/main/java/com/cloudera/tsexamples/JavaStocks.java
@@ -38,7 +38,6 @@ public class JavaStocks {
             Integer.parseInt(tokens[1]), Integer.parseInt(tokens[1]), 0, 0, 0, 0,
             ZoneId.systemDefault());
         String symbol = tokens[3];
-        int volume = Integer.parseInt(tokens[4]);
         double price = Double.parseDouble(tokens[5]);
         return RowFactory.create(Timestamp.from(dt.toInstant()), symbol, price);
     });
@@ -87,7 +86,7 @@ public class JavaStocks {
     );
 
     class StatsComparator implements Comparator<Tuple2<String,Double>>, java.io.Serializable {
-        public int compare(Tuple2<String,Double> a, Tuple2<String,Double> b) {
+        public int compare(Tuple2<String, Double> a, Tuple2<String, Double> b) {
             return a._2.compareTo(b._2);
         }
     }


### PR DESCRIPTION
I had some trouble with the JavaStocks sample using Spark 1.6.  Initially, the sample app would throw an exception while parsing the dates for the DateTimeIndex:

    Exception in thread "main" java.time.format.DateTimeParseException: Text '2015-08-03' could not be parsed at index 10
	at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:1949)
	at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1851)
    ....

I grabbed the index creation code from the Scala version to fix that, then ran into a problem with the Comparators that are used to get `max` and `min` from `dwStats`:

    Exception in thread "main" org.apache.spark.SparkException: Task not serializable
    ....
    Caused by: java.io.NotSerializableException: com.cloudera.tsexamples.JavaStocks$$Lambda$28/96749807

I added a new class that implements both Comparator and Serializable and used that to sort the stats results.  At this point, the demo runs but gives min and max results of `(AAL,NaN)`.  The Scala demo gives the correct results.  I'll update the PR if I can figure out why the Java version isn't working properly.